### PR TITLE
Remove "Fall Semester Announcement" banner

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,9 +24,5 @@
   <section class="banner">
     <h2>{{ site.title }}</h2>
     <p>{{ site.subtitle }}</p>
-
-    <div style="margin: 10em auto; padding: 15em auto; width: 100%; background-color:rgba(100,100,100,0.15);">
-      <a style="color: #FF6E6E; font-size: 5vw;" href="/fall/">Fall Semester Announcement</a>
-    </div>
   </section>
 </header>


### PR DESCRIPTION
It is redundant now.